### PR TITLE
gdl: Fix downloading from public shared drive urls

### DIFF
--- a/bash/download-utils.bash
+++ b/bash/download-utils.bash
@@ -102,7 +102,7 @@ _download_folder() {
     _newline "\n"
     "${EXTRA_LOG}" "justify" "${name}" "="
     "${EXTRA_LOG}" "justify" "Fetching folder" " details.." "-"
-    if ! info="$(_fetch "${API_URL}/drive/${API_VERSION}/files?q=%27${folder_id}%27+in+parents&fields=files(name,size,id,mimeType)&key=${API_KEY}")"; then
+    if ! info="$(_fetch "${API_URL}/drive/${API_VERSION}/files?q=%27${folder_id}%27+in+parents&fields=files(name,size,id,mimeType)&key=${API_KEY}&supportsAllDrives=true&includeItemsFromAllDrives=true")"; then
         "${QUIET:-_print_center}" "justify" "Error: Cannot" ", fetch folder details." "="
         printf "%s\n" "${info}" && return 1
     fi && _clear_line 1

--- a/bash/gdl.bash
+++ b/bash/gdl.bash
@@ -93,7 +93,7 @@ _check_id() {
     [[ $# = 0 ]] && printf "%s: Missing arguments\n" "${FUNCNAME[0]}" && return 1
     "${EXTRA_LOG}" "justify" "Validating URL/ID.." "-"
     declare id="${1}" json && unset NAME SIZE
-    if json="$(_fetch "${API_URL}/drive/${API_VERSION}/files/${id}?alt=json&fields=name,size,mimeType&key=${API_KEY}")"; then
+    if json="$(_fetch "${API_URL}/drive/${API_VERSION}/files/${id}?alt=json&fields=name,size,mimeType&key=${API_KEY}&supportsAllDrives=true&includeItemsFromAllDrives=true")"; then
         if ! _json_value code 1 1 <<< "${json}" 2>| /dev/null 1>&2; then
             NAME="$(_json_value name 1 1 <<< "${json}" || :)"
             mime="$(_json_value mimeType 1 1 <<< "${json}" || :)"

--- a/bash/release/gdl
+++ b/bash/release/gdl
@@ -202,7 +202,7 @@ files_size files_name files_list num_of_files folders_list num_of_folders
 _newline "\n"
 "$EXTRA_LOG" "justify" "$name" "="
 "$EXTRA_LOG" "justify" "Fetching folder" " details.." "-"
-if ! info="$(_fetch "$API_URL/drive/$API_VERSION/files?q=%27$folder_id%27+in+parents&fields=files(name,size,id,mimeType)&key=$API_KEY")";then
+if ! info="$(_fetch "$API_URL/drive/$API_VERSION/files?q=%27$folder_id%27+in+parents&fields=files(name,size,id,mimeType)&key=$API_KEY&supportsAllDrives=true&includeItemsFromAllDrives=true")";then
 "${QUIET:-_print_center}" "justify" "Error: Cannot" ", fetch folder details." "="
 printf "%s\n" "$info"&&return 1
 fi&&_clear_line 1
@@ -345,7 +345,7 @@ _check_id(){
 [[ $# == 0 ]]&&printf "%s: Missing arguments\n" "${FUNCNAME[0]}"&&return 1
 "$EXTRA_LOG" "justify" "Validating URL/ID.." "-"
 declare id="$1" json&&unset NAME SIZE
-if json="$(_fetch "$API_URL/drive/$API_VERSION/files/$id?alt=json&fields=name,size,mimeType&key=$API_KEY")";then
+if json="$(_fetch "$API_URL/drive/$API_VERSION/files/$id?alt=json&fields=name,size,mimeType&key=$API_KEY&supportsAllDrives=true&includeItemsFromAllDrives=true")";then
 if ! _json_value code 1 1 <<<"$json" 2>|/dev/null 1>&2;then
 NAME="$(_json_value name 1 1 <<<"$json"||:)"
 mime="$(_json_value mimeType 1 1 <<<"$json"||:)"

--- a/sh/download-utils.sh
+++ b/sh/download-utils.sh
@@ -104,7 +104,7 @@ _download_folder() {
     _newline "\n"
     "${EXTRA_LOG}" "justify" "${name_download_folder}" "="
     "${EXTRA_LOG}" "justify" "Fetching folder" " details.." "-"
-    if ! info_download_folder="$(_fetch "${API_URL}/drive/${API_VERSION}/files?q=%27${folder_id_download_folder}%27+in+parents&fields=files(name,size,id,mimeType)&key=${API_KEY}")"; then
+    if ! info_download_folder="$(_fetch "${API_URL}/drive/${API_VERSION}/files?q=%27${folder_id_download_folder}%27+in+parents&fields=files(name,size,id,mimeType)&key=${API_KEY}&supportsAllDrives=true&includeItemsFromAllDrives=true")"; then
         "${QUIET:-_print_center}" "justify" "Error: Cannot" ", fetch folder details." "="
         printf "%s\n" "${info_download_folder}" && return 1
     fi && _clear_line 1

--- a/sh/gdl.sh
+++ b/sh/gdl.sh
@@ -93,7 +93,7 @@ _check_id() {
     [ $# = 0 ] && printf "Missing arguments\n" && return 1
     "${EXTRA_LOG}" "justify" "Validating URL/ID.." "-"
     id_check_id="${1}" json_check_id=""
-    if json_check_id="$(_fetch "${API_URL}/drive/${API_VERSION}/files/${id_check_id}?alt=json&fields=name,size,mimeType&key=${API_KEY}")"; then
+    if json_check_id="$(_fetch "${API_URL}/drive/${API_VERSION}/files/${id_check_id}?alt=json&fields=name,size,mimeType&key=${API_KEY}&supportsAllDrives=true&includeItemsFromAllDrives=true")"; then
         if ! printf "%s\n" "${json_check_id}" | _json_value code 1 1 2>| /dev/null 1>&2; then
             NAME="$(printf "%s\n" "${json_check_id}" | _json_value name 1 1 || :)"
             mime_check_id="$(printf "%s\n" "${json_check_id}" | _json_value mimeType 1 1 || :)"

--- a/sh/release/gdl
+++ b/sh/release/gdl
@@ -210,7 +210,7 @@ num_of_files_download_folder num_of_folders_download_folder
 _newline "\n"
 "$EXTRA_LOG" "justify" "$name_download_folder" "="
 "$EXTRA_LOG" "justify" "Fetching folder" " details.." "-"
-if ! info_download_folder="$(_fetch "$API_URL/drive/$API_VERSION/files?q=%27$folder_id_download_folder%27+in+parents&fields=files(name,size,id,mimeType)&key=$API_KEY")";then
+if ! info_download_folder="$(_fetch "$API_URL/drive/$API_VERSION/files?q=%27$folder_id_download_folder%27+in+parents&fields=files(name,size,id,mimeType)&key=$API_KEY&supportsAllDrives=true&includeItemsFromAllDrives=true")";then
 "${QUIET:-_print_center}" "justify" "Error: Cannot" ", fetch folder details." "="
 printf "%s\n" "$info_download_folder"&&return 1
 fi&&_clear_line 1
@@ -379,7 +379,7 @@ _check_id(){
 [ $# = 0 ]&&printf "Missing arguments\n"&&return 1
 "$EXTRA_LOG" "justify" "Validating URL/ID.." "-"
 id_check_id="$1" json_check_id=""
-if json_check_id="$(_fetch "$API_URL/drive/$API_VERSION/files/$id_check_id?alt=json&fields=name,size,mimeType&key=$API_KEY")";then
+if json_check_id="$(_fetch "$API_URL/drive/$API_VERSION/files/$id_check_id?alt=json&fields=name,size,mimeType&key=$API_KEY&supportsAllDrives=true&includeItemsFromAllDrives=true")";then
 if ! printf "%s\n" "$json_check_id"|_json_value code 1 1 2>|/dev/null 1>&2;then
 NAME="$(printf "%s\n" "$json_check_id"|_json_value name 1 1||:)"
 mime_check_id="$(printf "%s\n" "$json_check_id"|_json_value mimeType 1 1||:)"


### PR DESCRIPTION
add two new parameters to api request which fetches the file/folder details

     supportsAllDrives=true and includeItemsFromAllDrives=true