### PR TITLE
Make python webserver use unbuffered IO.

### DIFF
--- a/release/bash/gdl
+++ b/release/bash/gdl
@@ -933,7 +933,7 @@ fi
 { curl -Is "http://localhost:$server_port_check_refresh_token"&&continue;}||break
 done
 if command -v python 1>/dev/null&&python -V|grep -q 'Python 3';then
-python <<EOF 1>"$TMPFILE.code" 2>&1&
+python -u <<EOF 1>"$TMPFILE.code" 2>&1&
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class handler(BaseHTTPRequestHandler):

--- a/release/sh/gdl
+++ b/release/sh/gdl
@@ -937,7 +937,7 @@ fi
 { curl -Is "http://localhost:$server_port_check_refresh_token"&&continue;}||break
 done
 if command -v python 1>/dev/null&&python -V|grep -q 'Python 3';then
-python <<EOF 1>"$TMPFILE.code" 2>&1&
+python -u <<EOF 1>"$TMPFILE.code" 2>&1&
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class handler(BaseHTTPRequestHandler):

--- a/src/common/auth-utils.sh
+++ b/src/common/auth-utils.sh
@@ -351,7 +351,7 @@ _check_refresh_token() {
 
         # https://docs.python.org/3/library/http.server.html
         if command -v python 1> /dev/null && python -V | grep -q 'Python 3'; then
-            python << EOF 1> "${TMPFILE}.code" 2>&1 &
+            python -u << EOF 1> "${TMPFILE}.code" 2>&1 &
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class handler(BaseHTTPRequestHandler):


### PR DESCRIPTION
When using the oauth functionality of gdl, I discovered a bug that made "$TMPFILE.code" always be an empty file. It seems that python was buffering output to the file and so the log would never be written to it. I added the `-u` flag to python which forced IO to be unbuffered and resolved the issue for me. The change passed the tests, but it wasn't clear the oauth component was tested.

As a side note some systems have python 2 and python 3 installed, but python is python 2. If python 3 is on a system, my understanding is that `python3` should always be that. 